### PR TITLE
feat: ignore non-code lines after directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ts-migrating",
-	"version": "1.3.0-beta.2",
+	"version": "1.3.0-beta.3",
 	"description": "Progressively Upgrade `tsconfigs.json`",
 	"author": "Jason Yu <me@ycmjason.com>",
 	"license": "MIT",

--- a/src/api/getSemanticDiagnostics.test.ts
+++ b/src/api/getSemanticDiagnostics.test.ts
@@ -247,4 +247,44 @@ enum FRUITS {
     const diagnostics = getSemanticDiagnosticsForFile(join(tmpDir, 'src/index.ts'));
     expect(diagnostics).toHaveLength(0);
   });
+
+  it('should ignore comments below', async () => {
+    const tmpDir = await setupTmpDir({
+      './tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2020',
+          module: 'commonjs',
+          outDir: './dist',
+          rootDir: './src',
+          strict: false,
+          esModuleInterop: true,
+          forceConsistentCasingInFileNames: true,
+          plugins: [
+            {
+              // ts will look up from the node_modules that the ts server is running from. e.g. ../../node_modules/ts-migrating
+              // this is why we add `ts-migrating` as dev dependency of itself.
+              name: 'ts-migrating',
+              compilerOptions: {
+                erasableSyntaxOnly: true,
+              },
+            },
+          ],
+          skipLibCheck: true,
+        },
+        include: ['src'],
+        exclude: ['node_modules', 'dist'],
+      }),
+      './src/index.ts': `// @ts-migrating
+// whatever here
+enum FRUITS {
+  APPLE,
+  BANANA,
+  KIWI,
+}
+`,
+    });
+
+    const diagnostics = getSemanticDiagnosticsForFile(join(tmpDir, 'src/index.ts'));
+    expect(diagnostics).toHaveLength(0);
+  });
 });

--- a/src/plugin/createTsMigratingProxyLanguageService.ts
+++ b/src/plugin/createTsMigratingProxyLanguageService.ts
@@ -44,10 +44,12 @@ export const createTsMigratingProxyLanguageService = ({
 
         return [
           ...getUnmarkedDiagnostics(newlyIntroducedDiagnostics, {
+            sourceFile,
             directiveComments,
             getLineNumberByPosition,
           }),
           ...getUnusedDirectiveComments(directiveComments, {
+            sourceFile,
             newlyIntroducedDiagnostics,
             getLineNumberByPosition,
           }).map(({ position, descriptor }) => ({


### PR DESCRIPTION
This implementation leverage the fact that TypeScript's AST does not contain comment as nodes.

When we see `@ts-migrating`, we ignore the plugin errors in the next AST node's line. 

This however mean that `@ts-migrating` will now not only skip subsequent comment lines, but also empty lines. For example:

```
// @ts-migrating

// bunch of words and empty lines

problematicLine();
```

This will still convert the `problematicLine()` to the old tsconfig. 

I am not 100% sure if this is a good behaviour... @m-basov thoughts?

fixes #5
