### PR TITLE
fix: reworked comment adding algorithm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ts-migrating",
-	"version": "1.3.0-beta.1",
+	"version": "1.3.0-beta.2",
 	"description": "Progressively Upgrade `tsconfigs.json`",
 	"author": "Jason Yu <me@ycmjason.com>",
 	"license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -748,6 +748,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}

--- a/src/api/insertSingleLineCommentsAtPositions.ts
+++ b/src/api/insertSingleLineCommentsAtPositions.ts
@@ -1,5 +1,5 @@
 import * as recast from 'recast';
-import * as typescriptParser from 'recast/parsers/babel-ts';
+import * as babelTsParser from 'recast/parsers/babel-ts';
 import { expect } from 'vitest';
 import { maxBy } from './utils/maxBy';
 
@@ -91,12 +91,11 @@ export const insertSingleLineCommentAtPositions = (
   comment: string,
   positions: number[],
 ): string => {
-  const ast = recast.parse(code, { parser: typescriptParser });
+  const ast = recast.parse(code, { parser: babelTsParser });
 
   const linesToAdd = new Set(positions.map(position => getLineColumnPosition(code, position).line));
 
   const naiveComments = new Map<number, NaiveCommentType>();
-
   const addedLineNumbers = new Set<number>();
   const commentTypeStack: CommentType[] = ['vanilla-naive'];
 

--- a/src/api/insertSingleLineCommentsAtPositions.ts
+++ b/src/api/insertSingleLineCommentsAtPositions.ts
@@ -1,6 +1,9 @@
 import * as recast from 'recast';
 import * as typescriptParser from 'recast/parsers/babel-ts';
 import { expect } from 'vitest';
+import { maxBy } from './utils/maxBy';
+
+const b = recast.types.builders;
 
 const getAbsolutePosition = (
   code: string,
@@ -42,9 +45,10 @@ const getLineColumnPosition = (
 
 if (import.meta.vitest) {
   const { it, describe } = import.meta.vitest;
-  const ts = await import('typescript/lib/tsserverlibrary');
 
-  describe('getAbsolutePosition / getLineColumnPosition', () => {
+  describe('getAbsolutePosition / getLineColumnPosition', async () => {
+    const ts = await import('typescript/lib/tsserverlibrary');
+
     it('should return the absolute position and back', () => {
       const code = `const a = 'hi'
 const b = 'bye'
@@ -76,6 +80,12 @@ hello()`;
   });
 }
 
+const extractIndent = (code: string): string => {
+  return code.replace(/^([ \t]*).*/s, '$1');
+};
+
+type NaiveCommentType = 'jsx-naive' | 'vanilla-naive';
+type CommentType = NaiveCommentType | 'vanilla-attach-to-node';
 export const insertSingleLineCommentAtPositions = (
   code: string,
   comment: string,
@@ -83,41 +93,130 @@ export const insertSingleLineCommentAtPositions = (
 ): string => {
   const ast = recast.parse(code, { parser: typescriptParser });
 
-  const linesToAdd: Set<number> = new Set(
-    positions.map(position => getLineColumnPosition(code, position).line),
-  );
+  const linesToAdd = new Set(positions.map(position => getLineColumnPosition(code, position).line));
+
+  const naiveComments = new Map<number, NaiveCommentType>();
+
+  const addedLineNumbers = new Set<number>();
+  const commentTypeStack: CommentType[] = ['vanilla-naive'];
 
   recast.types.visit(ast, {
+    visitTemplateElement(path) {
+      this.traverse(path);
+    },
+
     visitNode(path) {
       const { node } = path;
+
+      if (linesToAdd.size <= 0) {
+        return this.abort();
+      }
+
+      if (!node.loc) {
+        this.traverse(path);
+        return;
+      }
+
+      const preVisits: (() => void)[] = [];
+      const postVisits: (() => void)[] = [];
+
+      const setChildrenCommentType = (type: CommentType) => {
+        preVisits.push(() => {
+          commentTypeStack.push(type);
+        });
+
+        postVisits.push(() => {
+          commentTypeStack.pop();
+        });
+      };
+
       if (
-        !recast.types.namedTypes.Expression.check(node) &&
-        !recast.types.namedTypes.Statement.check(node)
+        recast.types.namedTypes.JSXElement.check(node) ||
+        recast.types.namedTypes.JSXFragment.check(node)
       ) {
-        return this.traverse(path);
+        setChildrenCommentType('jsx-naive');
       }
 
-      // we don't wanna add comment before jsx nodes
-      if (node.type.startsWith('JSX')) {
-        return this.traverse(path);
+      if (
+        recast.types.namedTypes.JSXExpressionContainer.check(node) ||
+        recast.types.namedTypes.JSXOpeningElement.check(node) ||
+        recast.types.namedTypes.JSXClosingElement.check(node)
+      ) {
+        setChildrenCommentType('vanilla-naive');
       }
 
-      const nodeLine = node.loc?.start.line;
-      if (nodeLine === undefined) return this.traverse(path);
-
-      if (linesToAdd.has(nodeLine)) {
-        linesToAdd.delete(nodeLine);
-        node.comments = [
-          recast.types.builders.commentLine(` ${comment}`, true),
-          ...(node?.comments ?? []),
-        ];
+      if (recast.types.namedTypes.TemplateLiteral.check(node)) {
+        setChildrenCommentType('vanilla-attach-to-node');
       }
 
-      return this.traverse(path);
+      const commentType = commentTypeStack.at(-1);
+      if (linesToAdd.has(node.loc.start.line)) {
+        linesToAdd.delete(node.loc.start.line);
+        switch (commentType) {
+          case 'vanilla-attach-to-node': {
+            addedLineNumbers.add(node.loc.start.line);
+            node.comments = [
+              ...(node?.comments ?? []),
+              b.commentLine.from({
+                value: ` ${comment}`,
+                leading: true,
+              }),
+            ];
+            break;
+          }
+          case 'vanilla-naive':
+          case 'jsx-naive': {
+            naiveComments.set(node.loc.start.line, commentType);
+            break;
+          }
+        }
+      }
+
+      for (const preVisit of preVisits) preVisit();
+      this.traverse(path);
+      for (const postVisit of postVisits) postVisit();
     },
   });
 
-  return recast.print(ast).code;
+  const adjustLineNumber = (originalLineNumber: number): number => {
+    // this represents the number of lines already added during ast traversal
+    const offset = [...addedLineNumbers].filter(
+      lineNumber => lineNumber <= originalLineNumber,
+    ).length;
+    return originalLineNumber + offset;
+  };
+
+  const adjustedAddedLineNumbers = new Set([...addedLineNumbers].map(adjustLineNumber));
+
+  const adjustedNaiveComments = new Map(
+    [...naiveComments].map(([lineNumber, commentType]) => [
+      adjustLineNumber(lineNumber),
+      commentType,
+    ]),
+  );
+
+  const lines = recast.print(ast).code.split('\n');
+  return lines
+    .flatMap((line, i) => {
+      const lineNumber = i + 1; // +1 because line numbers are 1-index
+      if (adjustedAddedLineNumbers.has(lineNumber)) return [line];
+
+      const commentType = adjustedNaiveComments.get(lineNumber);
+      if (commentType === undefined) return [line];
+
+      const indent = maxBy(
+        [extractIndent(line), extractIndent(lines[i - 1] ?? '')],
+        ({ length }) => length,
+      );
+      return [
+        {
+          'vanilla-naive': `${indent}// ${comment}`,
+          'jsx-naive': `${indent}{/* ${comment} */}`,
+        }[commentType],
+        line,
+      ];
+    })
+    .join('\n');
 };
 
 if (import.meta.vitest) {

--- a/src/api/utils/maxBy.ts
+++ b/src/api/utils/maxBy.ts
@@ -1,0 +1,138 @@
+// https://github.com/denoland/std/blob/main/collections/max_by.ts
+// Copyright 2018-2025 the Deno authors. MIT license.
+// This module is browser compatible.
+
+/**
+ * Returns the first element that is the largest value of the given function or
+ * undefined if there are no elements.
+ *
+ * @typeParam T The type of the elements in the array.
+ *
+ * @param array The array to find the maximum element in.
+ * @param selector The function to get the value to compare from each element.
+ *
+ * @returns The first element that is the largest value of the given function or
+ * undefined if there are no elements.
+ *
+ * @example Basic usage
+ * ```ts
+ * import { maxBy } from "@std/collections/max-by";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const people = [
+ *   { name: "Anna", age: 34 },
+ *   { name: "Kim", age: 42 },
+ *   { name: "John", age: 23 },
+ * ];
+ *
+ * const personWithMaxAge = maxBy(people, (person) => person.age);
+ *
+ * assertEquals(personWithMaxAge, { name: "Kim", age: 42 });
+ * ```
+ */
+export function maxBy<T>(array: Iterable<T>, selector: (el: T) => number): T | undefined;
+/**
+ * Returns the first element that is the largest value of the given function or
+ * undefined if there are no elements.
+ *
+ * @typeParam T The type of the elements in the array.
+ *
+ * @param array The array to find the maximum element in.
+ * @param selector The function to get the value to compare from each element.
+ *
+ * @returns The first element that is the largest value of the given function or
+ * undefined if there are no elements.
+ *
+ * @example Basic usage
+ * ```ts
+ * import { maxBy } from "@std/collections/max-by";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const people = [
+ *   { name: "Anna" },
+ *   { name: "Kim" },
+ *   { name: "John" },
+ * ];
+ *
+ * const personWithMaxName = maxBy(people, (person) => person.name);
+ *
+ * assertEquals(personWithMaxName, { name: "Kim" });
+ * ```
+ */
+export function maxBy<T>(array: Iterable<T>, selector: (el: T) => string): T | undefined;
+/**
+ * Returns the first element that is the largest value of the given function or
+ * undefined if there are no elements.
+ *
+ * @typeParam T The type of the elements in the array.
+ *
+ * @param array The array to find the maximum element in.
+ * @param selector The function to get the value to compare from each element.
+ *
+ * @returns The first element that is the largest value of the given function or
+ * undefined if there are no elements.
+ *
+ * @example Basic usage
+ * ```ts
+ * import { maxBy } from "@std/collections/max-by";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const people = [
+ *   { name: "Anna", age: 34n },
+ *   { name: "Kim", age: 42n },
+ *   { name: "John", age: 23n },
+ * ];
+ *
+ * const personWithMaxAge = maxBy(people, (person) => person.age);
+ *
+ * assertEquals(personWithMaxAge, { name: "Kim", age: 42n });
+ * ```
+ */
+export function maxBy<T>(array: Iterable<T>, selector: (el: T) => bigint): T | undefined;
+/**
+ * Returns the first element that is the largest value of the given function or
+ * undefined if there are no elements.
+ *
+ * @typeParam T The type of the elements in the array.
+ *
+ * @param array The array to find the maximum element in.
+ * @param selector The function to get the value to compare from each element.
+ *
+ * @returns The first element that is the largest value of the given function or
+ * undefined if there are no elements.
+ *
+ * @example Basic usage
+ * ```ts
+ * import { maxBy } from "@std/collections/max-by";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const people = [
+ *   { name: "Anna", startedAt: new Date("2020-01-01") },
+ *   { name: "Kim", startedAt: new Date("2021-03-01") },
+ *   { name: "John", startedAt: new Date("2020-03-01") },
+ * ];
+ *
+ * const personWithLastStartedAt = maxBy(people, (person) => person.startedAt);
+ *
+ * assertEquals(personWithLastStartedAt, { name: "Kim", startedAt: new Date("2021-03-01") });
+ * ```
+ */
+export function maxBy<T>(array: Iterable<T>, selector: (el: T) => Date): T | undefined;
+export function maxBy<T>(
+  array: Iterable<T>,
+  selector: ((el: T) => number) | ((el: T) => string) | ((el: T) => bigint) | ((el: T) => Date),
+): T | undefined {
+  let max: T | undefined;
+  let maxValue: ReturnType<typeof selector> | undefined;
+
+  for (const current of array) {
+    const currentValue = selector(current);
+
+    if (maxValue === undefined || currentValue > maxValue) {
+      max = current;
+      maxValue = currentValue;
+    }
+  }
+
+  return max;
+}

--- a/src/cli/commands/annotate.ts
+++ b/src/cli/commands/annotate.ts
@@ -21,18 +21,19 @@ const annotateDiagnostics = (source: string, diagnostics: readonly ts.Diagnostic
 
 if (import.meta.vitest) {
   const { describe, it, expect } = import.meta.vitest;
-  const ts = await import('typescript/lib/tsserverlibrary');
 
-  const createDiagnosticAtPosition = (pos: number): ts.Diagnostic => ({
-    start: pos,
-    category: ts.DiagnosticCategory.Warning,
-    code: 0,
-    file: undefined,
-    length: undefined,
-    messageText: '',
-  });
+  describe('annotateDiagnostics', async () => {
+    const ts = await import('typescript/lib/tsserverlibrary');
 
-  describe('annotateDiagnostics', () => {
+    const createDiagnosticAtPosition = (pos: number): ts.Diagnostic => ({
+      start: pos,
+      category: ts.DiagnosticCategory.Warning,
+      code: 0,
+      file: undefined,
+      length: undefined,
+      messageText: '',
+    });
+
     it('should add @ts-migrating before the first line', () => {
       expect(
         annotateDiagnostics(`const a = 'hello';`, [createDiagnosticAtPosition(0)]),
@@ -64,8 +65,8 @@ if (import.meta.vitest) {
       `);
     });
 
-    describe('[jt]sx', () => {
-      it('should add @ts-migrating correctly for tsx one-liner', () => {
+    describe('jsx', () => {
+      it('should add @ts-migrating correctly for jsx one-liner', () => {
         const code = 'const a = <div a={hi}></div>;';
         expect(
           annotateDiagnostics(code, [createDiagnosticAtPosition(code.indexOf('hi'))]),
@@ -75,28 +76,83 @@ if (import.meta.vitest) {
         `);
       });
 
-      it('should add @ts-migrating correctly for tsx attributes', () => {
+      it('should add @ts-migrating correctly for jsx attributes', () => {
         const code = 'const a = <div\n  a={hi}>\n</div>;';
         expect(
           annotateDiagnostics(code, [createDiagnosticAtPosition(code.indexOf('hi'))]),
         ).toMatchInlineSnapshot(`
           "const a = <div
-            a={// @ts-migrating
-            hi}>
+            // @ts-migrating
+            a={hi}>
           </div>;"
         `);
       });
 
-      it('should add @ts-migrating correctly for tsx expressions', () => {
+      it('should add @ts-migrating correctly for jsx expressions', () => {
         const code = 'const a = <div>\n  {hi}\n</div>;';
         expect(
           annotateDiagnostics(code, [createDiagnosticAtPosition(code.indexOf('hi'))]),
         ).toMatchInlineSnapshot(`
-        "const a = <div>
-          {// @ts-migrating
-          hi}
-        </div>;"
-      `);
+          "const a = <div>
+            {/* @ts-migrating */}
+            {hi}
+          </div>;"
+        `);
+      });
+
+      it('should add @ts-migrating correctly for jsx fragment', () => {
+        const code = 'const a = <>\n  {hi}\n</>;';
+        expect(
+          annotateDiagnostics(code, [createDiagnosticAtPosition(code.indexOf('hi'))]),
+        ).toMatchInlineSnapshot(`
+          "const a = <>
+            {/* @ts-migrating */}
+            {hi}
+          </>;"
+        `);
+      });
+
+      it('should add @ts-migrating correctly for jsx expressions with attributes', () => {
+        const code = 'const a = <div\n  id="yo">\n<div>{hi}</div>\n</div>; const b = 3';
+        expect(
+          annotateDiagnostics(code, [
+            createDiagnosticAtPosition(code.indexOf('hi')),
+            createDiagnosticAtPosition(code.indexOf('yo')),
+          ]),
+        ).toMatchInlineSnapshot(`
+          "const a = <div
+            // @ts-migrating
+            id="yo">
+            {/* @ts-migrating */}
+          <div>{hi}</div>
+          </div>; const b = 3"
+        `);
+      });
+
+      it('should add @ts-migrating correctly for iife within jsx', () => {
+        const code = `const a = <Button>
+  {(() => { f(); })()}
+  {(() => {
+    g();
+  })()}
+</Button>
+`;
+        expect(
+          annotateDiagnostics(code, [
+            createDiagnosticAtPosition(code.indexOf('f')),
+            createDiagnosticAtPosition(code.indexOf('g')),
+          ]),
+        ).toMatchInlineSnapshot(`
+          "const a = <Button>
+            {/* @ts-migrating */}
+            {(() => { f(); })()}
+            {(() => {
+              // @ts-migrating
+              g();
+            })()}
+          </Button>
+          "
+        `);
       });
     });
 
@@ -106,9 +162,9 @@ if (import.meta.vitest) {
         expect(
           annotateDiagnostics(code, [createDiagnosticAtPosition(code.indexOf('A'))]),
         ).toMatchInlineSnapshot(`
-        "// @ts-migrating
-        enum A {}"
-      `);
+          "// @ts-migrating
+          enum A { }"
+        `);
       });
 
       it('should add @ts-migrating correctly for weird formatted enum', () => {
@@ -116,10 +172,10 @@ if (import.meta.vitest) {
         expect(
           annotateDiagnostics(code, [createDiagnosticAtPosition(code.indexOf('A'))]),
         ).toMatchInlineSnapshot(`
-        "enum
-        // @ts-migrating
-        A { }"
-      `);
+          "enum
+          // @ts-migrating
+          A { }"
+        `);
       });
     });
 
@@ -129,10 +185,10 @@ if (import.meta.vitest) {
         expect(
           annotateDiagnostics(code, [createDiagnosticAtPosition(code.indexOf('awesome'))]),
         ).toMatchInlineSnapshot(`
-        "const message = \`I am
-         freaking \${// @ts-migrating
-        awesome}.\`;"
-      `);
+          "const message = \`I am
+           freaking \${// @ts-migrating
+          awesome}.\`;"
+        `);
       });
 
       it('should add @ts-migrating correctly for string template with multiple errors', () => {
@@ -146,15 +202,155 @@ if (import.meta.vitest) {
             createDiagnosticAtPosition(code.indexOf('lovely')),
           ]),
         ).toMatchInlineSnapshot(`
-        "const message = \`I am
-         freaking \${// @ts-migrating
-        awesome}, \${cool}
-        , \${// @ts-migrating
-        fantastic}, 
-        \${// @ts-migrating
-        lovely}.\`;"
-      `);
+          "const message = \`I am
+           freaking \${// @ts-migrating
+          awesome}, \${cool}
+          , \${// @ts-migrating
+          fantastic}, 
+          \${// @ts-migrating
+          lovely}.\`;"
+        `);
       });
+
+      it('should add @ts-migrating correctly for naive lines after string template', () => {
+        const code = 'const x = `I am ${cool}\n${awesome}`;\nf();\ng();';
+        expect(
+          annotateDiagnostics(code, [
+            createDiagnosticAtPosition(code.indexOf('cool')),
+            createDiagnosticAtPosition(code.indexOf('awesome')),
+            createDiagnosticAtPosition(code.indexOf('f')),
+            createDiagnosticAtPosition(code.indexOf('g')),
+          ]),
+        ).toMatchInlineSnapshot(`
+          "// @ts-migrating
+          const x = \`I am \${cool}
+          \${// @ts-migrating
+          awesome}\`;
+          // @ts-migrating
+          f();
+          // @ts-migrating
+          g();"
+        `);
+      });
+
+      // https://github.com/ycmjason/ts-migrating/issues/2
+      it('issue #2', () => {
+        const code = `const x = z\`I am \${cool}
+\${(awesome) => {
+  f();
+}}\`;
+g();`;
+        expect(
+          annotateDiagnostics(code, [
+            createDiagnosticAtPosition(code.indexOf('cool')),
+            createDiagnosticAtPosition(code.indexOf('awesome')),
+            createDiagnosticAtPosition(code.indexOf('f')),
+            createDiagnosticAtPosition(code.indexOf('g')),
+          ]),
+        ).toMatchInlineSnapshot(`
+          "// @ts-migrating
+          const x = z\`I am \${cool}
+          \${// @ts-migrating
+          awesome => {
+            // @ts-migrating
+            f();
+          }}\`;
+          // @ts-migrating
+          g();"
+        `);
+      });
+    });
+
+    it('should add @ts-migrating comment last', () => {
+      const code = '// hello world\nconst x = 3;';
+      expect(
+        annotateDiagnostics(code, [createDiagnosticAtPosition(code.indexOf('x'))]),
+      ).toMatchInlineSnapshot(`
+        "// hello world
+        // @ts-migrating
+        const x = 3;"
+      `);
+    });
+
+    it('should add @ts-migrating correctly for object computed property name', () => {
+      const code = 'const obj = {\n  [a]: 3,\n}';
+      expect(
+        annotateDiagnostics(code, [createDiagnosticAtPosition(code.indexOf('a'))]),
+      ).toMatchInlineSnapshot(`
+        "const obj = {
+          // @ts-migrating
+          [a]: 3,
+        }"
+      `);
+    });
+
+    describe('if-else', () => {
+      it('should add @ts-migrating correctly for else if', () => {
+        const code = `if (a) {
+f();
+} else if (b) {
+} else {
+}`;
+        expect(
+          annotateDiagnostics(code, [createDiagnosticAtPosition(code.indexOf('b'))]),
+        ).toMatchInlineSnapshot(`
+          "if (a) {
+          f();
+          // @ts-migrating
+          } else if (b) {
+          } else {
+          }"
+        `);
+      });
+
+      it('should add @ts-migrating correctly for else if', () => {
+        const code = `if (a) {
+f();
+}
+else if (b) {
+} else {
+}`;
+        expect(
+          annotateDiagnostics(code, [createDiagnosticAtPosition(code.indexOf('b'))]),
+        ).toMatchInlineSnapshot(`
+          "if (a) {
+          f();
+          }
+          // @ts-migrating
+          else if (b) {
+          } else {
+          }"
+        `);
+      });
+    });
+
+    describe('for-loop', () => {
+      it('should add @ts-migrating correctly for for-loops', () => {
+        const code = `for (let i = 0; i < callbacks.length; i += 1) {
+  callbacks[i](event);
+}`;
+
+        expect(
+          annotateDiagnostics(code, [createDiagnosticAtPosition(code.indexOf('callbacks[i]'))]),
+        ).toMatchInlineSnapshot(`
+          "for (let i = 0; i < callbacks.length; i += 1) {
+            // @ts-migrating
+            callbacks[i](event);
+          }"
+        `);
+      });
+    });
+
+    it('should deal with chains correctly', () => {
+      const code = `const panel1ScrollHeight = jest
+      .spyOn(panel1, "scrollHeight", "get");`;
+      expect(
+        annotateDiagnostics(code, [createDiagnosticAtPosition(code.indexOf('spyOn'))]),
+      ).toMatchInlineSnapshot(`
+        "const panel1ScrollHeight = jest
+              // @ts-migrating
+              .spyOn(panel1, "scrollHeight", "get");"
+      `);
     });
   });
 }

--- a/src/cli/commands/annotate.ts
+++ b/src/cli/commands/annotate.ts
@@ -352,6 +352,154 @@ else if (b) {
               .spyOn(panel1, "scrollHeight", "get");"
       `);
     });
+
+    // Currently failing due to: https://github.com/benjamn/recast/issues/1423
+    it.skip('should annotate correctly for weird formatted ternary', () => {
+      // failed case from https://github.com/bluesky-social/social-app/blob/fd37d92f85ddf0f075a67c4e9b2d85bef38f1835/src/components/KnownFollowers.tsx#L177-L245
+      const code = `const a = <Text>
+  {slice.length >= 2 ? (
+    // 2-n followers, including blocks
+    serverCount > 2 ? (
+      <Trans>
+        Followed by{' '}
+        <Text emoji key={aaa.profile.did} style={textStyle}>
+          {bbb.profile.displayName}
+        </Text>
+        ,{' '}
+        <Text emoji key={ccc.profile.did} style={textStyle}>
+          {ddd.profile.displayName}
+        </Text>
+        , and{' '}
+        <Plural
+          value={serverCount - 2}
+          one="# other"
+          other="# others"
+        />
+      </Trans>
+    ) : (
+      // only 2
+      <Trans>
+        Followed by{' '}
+        <Text emoji key={eee.profile.did} style={textStyle}>
+          {fff.profile.displayName}
+        </Text>{' '}
+        and{' '}
+        <Text emoji key={ggg.profile.did} style={textStyle}>
+          {hhh.profile.displayName}
+        </Text>
+      </Trans>
+    )
+  ) : serverCount > 1 ? (
+    // 1-n followers, including blocks
+    <Trans>
+      Followed by{' '}
+      <Text emoji key={iii.profile.did} style={textStyle}>
+        {jjj.profile.displayName}
+      </Text>{' '}
+      and{' '}
+      <Plural
+        value={serverCount - 1}
+        one="# other"
+        other="# others"
+      />
+    </Trans>
+  ) : (
+    // only 1
+    <Trans>
+      Followed by{' '}
+      <Text emoji key={lll.profile.did} style={textStyle}>
+        {mmm.profile.displayName}
+      </Text>
+    </Trans>
+  )}
+</Text>`;
+      expect(
+        annotateDiagnostics(code, [
+          createDiagnosticAtPosition(code.indexOf('aaa')),
+          createDiagnosticAtPosition(code.indexOf('bbb')),
+          createDiagnosticAtPosition(code.indexOf('ccc')),
+          createDiagnosticAtPosition(code.indexOf('ddd')),
+          createDiagnosticAtPosition(code.indexOf('eee')),
+          createDiagnosticAtPosition(code.indexOf('fff')),
+          createDiagnosticAtPosition(code.indexOf('ggg')),
+          createDiagnosticAtPosition(code.indexOf('hhh')),
+          createDiagnosticAtPosition(code.indexOf('iii')),
+          createDiagnosticAtPosition(code.indexOf('jjj')),
+          createDiagnosticAtPosition(code.indexOf('lll')),
+          createDiagnosticAtPosition(code.indexOf('mmm')),
+        ]),
+      ).toMatchInlineSnapshot(`
+        "const a = <Text>
+          {slice.length >= 2 ? (
+            // 2-n followers, including blocks
+            serverCount > 2 ? (
+              <Trans>
+                Followed by{' '}
+                {/* @ts-migrating */}
+                <Text emoji key={aaa.profile.did} style={textStyle}>
+                  {/* @ts-migrating */}
+                  {bbb.profile.displayName}
+                </Text>
+                ,{' '}
+                {/* @ts-migrating */}
+                <Text emoji key={ccc.profile.did} style={textStyle}>
+                  {/* @ts-migrating */}
+                  {ddd.profile.displayName}
+                </Text>
+                , and{' '}
+                <Plural
+                  value={serverCount - 2}
+                  one="# other"
+                  other="# others"
+                />
+              </Trans>
+            ) : (
+              // only 2
+              <Trans>
+                Followed by{' '}
+                {/* @ts-migrating */}
+                <Text emoji key={eee.profile.did} style={textStyle}>
+                  {/* @ts-migrating */}
+                  {fff.profile.displayName}
+                </Text>{' '}
+                and{' '}
+                {/* @ts-migrating */}
+                <Text emoji key={ggg.profile.did} style={textStyle}>
+                  {/* @ts-migrating */}
+                  {hhh.profile.displayName}
+                </Text>
+              </Trans>
+            )
+          ) : serverCount > 1 ? (
+            // 1-n followers, including blocks
+            <Trans>
+              Followed by{' '}
+              {/* @ts-migrating */}
+              <Text emoji key={iii.profile.did} style={textStyle}>
+                {/* @ts-migrating */}
+                {jjj.profile.displayName}
+              </Text>{' '}
+              and{' '}
+              <Plural
+                value={serverCount - 1}
+                one="# other"
+                other="# others"
+              />
+            </Trans>
+          ) : (
+            // only 1
+            <Trans>
+              Followed by{' '}
+              {/* @ts-migrating */}
+              <Text emoji key={lll.profile.did} style={textStyle}>
+                {/* @ts-migrating */}
+                {mmm.profile.displayName}
+              </Text>
+            </Trans>
+          )}
+        </Text>"
+      `);
+    });
   });
 }
 


### PR DESCRIPTION
reworked the algorithm for adding comments.

the main pain point of the original implementation in #4 was that adding comment via AST has its limitations. we cannot for example add comment here (or at least I haven't found a way to do that):
```ts
happy
 // here
 .birthday()
```

this is because there's no node for the `.` that begins on `.birthday()`. the first node on that line would be the Identifier node for `birthday`. so if we used AST to insert comment, we end up with:

```ts
happy
 .// here
 birthday()
```

which is obviously horrible.


so I introduced some naive adding again since it seems to be more reliable. I only use AST for:

1. Inserting `// @ts-migrating` in string template
2. Keeping track of which line is in JSX and which line is vanilla.


There are some edge cases where recast / babel parser would not preserve the original formatting of the code which result in incorrect line ordering, this causes the annotation to fail. I have added an example where this will fail [here](https://github.com/ycmjason/ts-migrating/pull/7/commits/be5649b3e6cef51ff8c3b5459bab33d81f24e664#diff-8c3f90a382148734e5f0b694378e0a5af32ea32b721de61e560be1930fea5d0bR356) and I have raised an issue in https://github.com/benjamn/recast/issues/1423.

related #1, #2 