### PR TITLE
Fix plugin diagnostics for non-TS/JS files (issue #14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ts-migrating",
-	"version": "1.4.1",
+	"version": "1.4.2-beta.0",
 	"description": "Progressively Upgrade `tsconfigs.json`",
 	"author": "Jason Yu <me@ycmjason.com>",
 	"license": "MIT",

--- a/src/api/getSemanticDiagnostics.issue14.test.ts
+++ b/src/api/getSemanticDiagnostics.issue14.test.ts
@@ -1,0 +1,77 @@
+import { rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import { getSemanticDiagnosticsForFile } from './getSemanticDiagnostics';
+import { isPluginDiagnostic } from './isPluginDiagnostic';
+
+/**
+ * End-to-end coverage for https://github.com/ycmjason/ts-migrating/issues/14
+ *
+ * These run the *real* plugin loaded by a real `ts.server.ProjectService`
+ * (see ./typescript/projectService) via `getSemanticDiagnosticsForFile`.
+ *
+ * Note: a plain TypeScript program never pulls a `.html` file in (TS gates
+ * program membership by extension), and only the Angular Language Service
+ * attaches templates to the plugin's project. We can't install Angular here, so
+ * the precise "template is in the program" regression is covered deterministically
+ * in ../plugin/createTsMigratingProxyLanguageService.test.ts. These E2E tests
+ * prove the plugin pipeline runs end-to-end and never flags a template file.
+ */
+
+const ROOT = join(tmpdir(), 'ts-migrating-issue14-e2e');
+afterAll(() => rmSync(ROOT, { recursive: true, force: true }));
+
+let counter = 0;
+const setupTmpDir = async (files: Record<string, string>): Promise<string> => {
+  const dir = join(ROOT, (counter++).toString());
+  for (const [relativePath, content] of Object.entries(files)) {
+    const fullPath = join(dir, relativePath);
+    await mkdir(dirname(fullPath), { recursive: true });
+    await writeFile(fullPath, content, 'utf8');
+  }
+  return dir;
+};
+
+const tsconfig = JSON.stringify({
+  compilerOptions: {
+    target: 'ES2020',
+    module: 'commonjs',
+    strict: false,
+    skipLibCheck: true,
+    esModuleInterop: true,
+    forceConsistentCasingInFileNames: true,
+    plugins: [{ name: 'ts-migrating', compilerOptions: { strict: true } }],
+  },
+  include: ['src'],
+  exclude: ['node_modules', 'dist'],
+});
+
+describe('issue #14 (e2e): Angular-style component through the real plugin', () => {
+  it('flags target-config errors in the component .ts (pipeline runs end-to-end)', async () => {
+    const dir = await setupTmpDir({
+      './tsconfig.json': tsconfig,
+      // `noImplicitAny` (part of `strict`) flags the untyped parameter.
+      './src/app.component.ts': `export class AppComponent {\n  greet(name) {\n    return \`hi \${name}\`;\n  }\n}\n`,
+    });
+
+    const pluginDiagnostics = getSemanticDiagnosticsForFile(
+      join(dir, 'src/app.component.ts'),
+    ).filter(isPluginDiagnostic);
+
+    expect(pluginDiagnostics.length).toBeGreaterThan(0);
+  });
+
+  it('does not surface plugin diagnostics for an .html template (and does not throw)', async () => {
+    const dir = await setupTmpDir({
+      './tsconfig.json': tsconfig,
+      './src/app.component.ts': `export class AppComponent {\n  title = 'hello';\n}\n`,
+      './src/app.component.html': `<div class="title">{{ title }}</div>\n<span>{{ undefinedVariable }}</span>\n`,
+    });
+
+    const diagnostics = getSemanticDiagnosticsForFile(join(dir, 'src/app.component.html'));
+
+    expect(diagnostics.filter(isPluginDiagnostic)).toEqual([]);
+  });
+});

--- a/src/plugin/createTsMigratingProxyLanguageService.test.ts
+++ b/src/plugin/createTsMigratingProxyLanguageService.test.ts
@@ -1,0 +1,85 @@
+import ts from 'typescript/lib/tsserverlibrary';
+import { describe, expect, it } from 'vitest';
+import { isPluginDiagnostic } from '../api/isPluginDiagnostic';
+import { createTsMigratingProxyLanguageService } from './createTsMigratingProxyLanguageService';
+
+const sourceFileOf = (fileName: string, content: string): ts.SourceFile =>
+  ts.createSourceFile(fileName, content, ts.ScriptTarget.ESNext, true);
+
+const parseDiagnosticsOf = (sourceFile: ts.SourceFile): ts.Diagnostic[] =>
+  ((sourceFile as unknown as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ??
+    []) as ts.Diagnostic[];
+
+const fakeError = (file: ts.SourceFile): ts.Diagnostic => ({
+  category: ts.DiagnosticCategory.Error,
+  code: 2304,
+  file,
+  start: 0,
+  length: 1,
+  messageText: "Cannot find name 'x'.",
+});
+
+/**
+ * Builds the proxy with a base (`from`) service that exposes `sourceFile` for
+ * `fileName` and reports no plain-TS errors for it — mirroring an Angular-aware
+ * service whose `.html` template is in the program — and a secondary (`to`)
+ * service that would report `secondaryDiagnostics` for that file.
+ */
+const buildProxy = ({
+  fileName,
+  sourceFile,
+  secondaryDiagnostics,
+}: {
+  fileName: string;
+  sourceFile: ts.SourceFile;
+  secondaryDiagnostics: ts.Diagnostic[];
+}): ts.LanguageService => {
+  const fromLanguageService = {
+    getSemanticDiagnostics: () => [],
+    getTodoComments: () => [],
+    getProgram: () => ({
+      getSourceFile: (f: string) => (f === fileName ? sourceFile : undefined),
+    }),
+  } as unknown as ts.LanguageService;
+
+  const toLanguageService = {
+    getSemanticDiagnostics: (f: string) => (f === fileName ? secondaryDiagnostics : []),
+  } as unknown as ts.LanguageService;
+
+  return createTsMigratingProxyLanguageService({ ts, fromLanguageService, toLanguageService });
+};
+
+describe('createTsMigratingProxyLanguageService', () => {
+  // https://github.com/ycmjason/ts-migrating/issues/14
+  it('does not surface diagnostics for non-TS/JS files (e.g. Angular .html templates)', () => {
+    const fileName = '/proj/app.component.html';
+    const sourceFile = sourceFileOf(fileName, '<div class="title">{{ title }}</div>\n');
+    const secondaryDiagnostics = parseDiagnosticsOf(sourceFile);
+
+    // sanity check: parsing the template as TS really does produce errors, so a
+    // missing guard would surface them.
+    expect(secondaryDiagnostics.length).toBeGreaterThan(0);
+
+    const proxy = buildProxy({ fileName, sourceFile, secondaryDiagnostics });
+    const pluginDiagnostics = proxy.getSemanticDiagnostics(fileName).filter(isPluginDiagnostic);
+
+    expect(pluginDiagnostics).toEqual([]);
+  });
+
+  it.each([
+    '/proj/app.component.ts',
+    '/proj/widget.tsx',
+    '/proj/legacy.js',
+    '/proj/legacy.jsx',
+    '/proj/util.mts',
+    '/proj/util.cjs',
+  ])('still surfaces newly-introduced target-config errors for %s', fileName => {
+    const sourceFile = sourceFileOf(fileName, 'export const value = 1;\n');
+    const secondaryDiagnostics = [fakeError(sourceFile)];
+
+    const proxy = buildProxy({ fileName, sourceFile, secondaryDiagnostics });
+    const pluginDiagnostics = proxy.getSemanticDiagnostics(fileName).filter(isPluginDiagnostic);
+
+    expect(pluginDiagnostics).toHaveLength(1);
+  });
+});

--- a/src/plugin/createTsMigratingProxyLanguageService.ts
+++ b/src/plugin/createTsMigratingProxyLanguageService.ts
@@ -2,6 +2,7 @@ import type TsServerLibrary from 'typescript/lib/tsserverlibrary';
 import { DIRECTIVE } from './constants/DIRECTIVE';
 import { UNUSED_DIRECTIVE_DIAGNOSTIC_CODE } from './constants/UNUSED_DIRECTIVE_DIAGNOSTIC_CODE';
 import { createOverwritingProxy } from './createOverwritingProxy';
+import { isCheckableSourceFile } from './isCheckableSourceFile';
 import { differenceBy } from './utils/collections';
 import {
   brandifyDiagnostic,
@@ -23,6 +24,13 @@ export const createTsMigratingProxyLanguageService = ({
     getQuickInfoAtPosition: (...attrs) => toLanguageService.getQuickInfoAtPosition(...attrs),
     getSemanticDiagnostics: fileName => {
       const diagnostics = fromLanguageService.getSemanticDiagnostics(fileName);
+
+      // Other language-service plugins own non-TS/JS files — most notably the
+      // Angular Language Service owns `.html` templates. Our secondary service
+      // has none of those plugins, so running it over such a file would parse
+      // the file as plain TypeScript and surface bogus errors.
+      // https://github.com/ycmjason/ts-migrating/issues/14
+      if (!isCheckableSourceFile(fileName)) return diagnostics;
 
       const sourceFile = fromLanguageService.getProgram()?.getSourceFile(fileName);
 

--- a/src/plugin/isCheckableSourceFile.test.ts
+++ b/src/plugin/isCheckableSourceFile.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { isCheckableSourceFile } from './isCheckableSourceFile';
+
+describe('isCheckableSourceFile', () => {
+  it.each([
+    'app.component.ts',
+    'app.component.tsx',
+    'module.mts',
+    'module.cts',
+    'legacy.js',
+    'legacy.jsx',
+    'module.mjs',
+    'module.cjs',
+    '/abs/path/to/File.TS',
+  ])('is true for TS/JS source file %s', fileName => {
+    expect(isCheckableSourceFile(fileName)).toBe(true);
+  });
+
+  it.each([
+    'app.component.html',
+    'styles.css',
+    'data.json',
+    'component.vue',
+    'README.md',
+    'logo.svg',
+    'noextension',
+    'archive.ts.bak',
+  ])('is false for non-source file %s', fileName => {
+    expect(isCheckableSourceFile(fileName)).toBe(false);
+  });
+});

--- a/src/plugin/isCheckableSourceFile.ts
+++ b/src/plugin/isCheckableSourceFile.ts
@@ -1,0 +1,18 @@
+/**
+ * Whether ts-migrating should run its target-config type-check over `fileName`.
+ *
+ * The plugin computes "what errors would the target compilerOptions introduce"
+ * by running a secondary, plugin-less TypeScript language service. That service
+ * knows nothing about other language-service plugins — most notably the Angular
+ * Language Service — so handing it their files (e.g. Angular `.html` templates)
+ * makes it parse them as plain TypeScript and report bogus errors.
+ *
+ * We therefore only run over real TypeScript/JavaScript source files:
+ * `.ts` `.tsx` `.mts` `.cts` `.js` `.jsx` `.mjs` `.cjs` (the `.js`/`.jsx` family
+ * matters for `checkJs` migrations). Everything else — `.html`, `.json`, `.vue`,
+ * … — is left to whichever plugin owns it.
+ *
+ * See https://github.com/ycmjason/ts-migrating/issues/14
+ */
+export const isCheckableSourceFile = (fileName: string): boolean =>
+  /\.(?:[cm]?[jt]sx?)$/i.test(fileName);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     root: 'src',
     includeSource: ['**/*.{js,ts,tsx,jsx}'],
-    setupFiles: ['../vitest.setup.ts'],
+    globalSetup: ['../vitest.globalSetup.ts'],
   },
 });

--- a/vitest.globalSetup.ts
+++ b/vitest.globalSetup.ts
@@ -1,0 +1,17 @@
+import { execSync } from 'node:child_process';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Build the package once before the whole test run.
+ *
+ * Tests that exercise the plugin load it from `dist/` (via the self-linked
+ * `ts-migrating` dependency), so a build must exist. Running this in vitest's
+ * `globalSetup` (once, in the main process) rather than a per-file `beforeAll`
+ * avoids parallel workers racing to delete and rebuild the shared `dist/`
+ * directory at the same time.
+ */
+export default (): void => {
+  rmSync(join(process.cwd(), 'dist'), { recursive: true, force: true });
+  execSync('pnpm build', { stdio: 'ignore' });
+};

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,9 +1,0 @@
-import { execSync } from 'node:child_process';
-import { rmSync } from 'node:fs';
-import { join } from 'node:path';
-import { beforeAll } from 'vitest';
-
-beforeAll(() => {
-  rmSync(join(__dirname, 'dist'), { recursive: true, force: true });
-  execSync('pnpm build', { stdio: 'ignore' });
-});


### PR DESCRIPTION
## Summary

Fixes a bug where the ts-migrating plugin would surface spurious diagnostics for non-TypeScript/JavaScript files (e.g., Angular `.html` templates) when those files are included in the TypeScript program by other language-service plugins.

## Problem

The plugin runs a secondary TypeScript language service without other plugins to compute "what errors would the target compilerOptions introduce." When other plugins (like the Angular Language Service) attach non-TS/JS files to the program, the secondary service would parse these files as plain TypeScript and report bogus errors.

## Changes

- **Added `isCheckableSourceFile()`**: New utility function that determines whether a file should be type-checked by ts-migrating. Only accepts `.ts`, `.tsx`, `.mts`, `.cts`, `.js`, `.jsx`, `.mjs`, and `.cjs` files (case-insensitive). All other files are delegated to their owning plugins.

- **Updated `createTsMigratingProxyLanguageService()`**: Added an early return in `getSemanticDiagnostics()` that skips the secondary type-check for non-checkable files, preventing bogus errors from being surfaced.

- **Added comprehensive test coverage**:
  - Unit tests for `isCheckableSourceFile()` covering both valid and invalid file extensions
  - Unit tests for the proxy language service verifying it filters non-TS/JS files while still reporting errors for actual source files
  - End-to-end tests that exercise the real plugin pipeline with temporary TypeScript projects

- **Improved test infrastructure**: Migrated from per-file `beforeAll` setup to vitest's `globalSetup` hook to avoid race conditions when parallel test workers rebuild the shared `dist/` directory.

## Implementation Details

The fix is minimal and surgical: a single file-extension check gates whether the secondary type-check runs. This preserves the plugin's ability to report target-config errors for actual TypeScript/JavaScript files while completely avoiding interference with other plugins' files.

https://claude.ai/code/session_01VJSn82d1rvGbinpv4ZkjFa